### PR TITLE
Fix for Grafana v5.1 permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
     restart: on-failure
     ports:
       - "8000:3000"
+    user: "root"
     volumes:
       - ./volumes/grafana:/var/lib/grafana
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Grafana changed user id from 104 to 472 since version 5.1 (April '18). Updating it will lead to errors running Grafana. You can run it as "root" to avoid permission conflicts.
See: http://docs.grafana.org/installation/docker/